### PR TITLE
feat: ET-1429: Single Line Commit Messages

### DIFF
--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -25,6 +25,8 @@ import { getConfig } from './config';
 
 const config = getConfig();
 
+let issueID = '';
+
 const getGitRemotes = async () => {
   const { stdout } = await execa('git', ['remote']);
   return stdout.split('\n').filter((remote) => Boolean(remote.trim()));
@@ -182,9 +184,7 @@ export async function commit(
     process.exit(1);
   }
 
-  let issueID = '';
-
-  if (config?.OCO_ISSUE_ENABLED) {
+  if (config?.OCO_ISSUE_ENABLED && !issueID) {
     const issueIDSpinner = spinner();
 
     issueIDSpinner.start('Confirming Issue ID');

--- a/src/generateCommitMessageFromGitDiff.ts
+++ b/src/generateCommitMessageFromGitDiff.ts
@@ -65,7 +65,7 @@ export const generateCommitMessageByDiff = async (
         await delay(2000);
       }
 
-      const commitMessagesNewLines = commitMessages.join('\n\n');
+      const commitMessagesNewLines = commitMessages.join('\n');
 
       const combinedCommitMessage = await api.generateSingleCommitMessage(commitMessagesNewLines);
 

--- a/src/generateCommitMessageFromGitDiff.ts
+++ b/src/generateCommitMessageFromGitDiff.ts
@@ -55,8 +55,8 @@ export const generateCommitMessageByDiff = async (
     if (tokenCount(diff) >= MAX_REQUEST_TOKENS) {
       const commitMessagePromises = await getCommitMsgsPromisesFromFileDiffs(
         diff,
-        issueID,
-        MAX_REQUEST_TOKENS
+        MAX_REQUEST_TOKENS,
+        issueID
       );
 
       const commitMessages = [];
@@ -65,7 +65,14 @@ export const generateCommitMessageByDiff = async (
         await delay(2000);
       }
 
-      return commitMessages.join('\n\n');
+      const commitMessagesNewLines = commitMessages.join('\n\n');
+
+      const combinedCommitMessage = await api.generateSingleCommitMessage(commitMessagesNewLines);
+
+      if (!combinedCommitMessage)
+      throw new Error(GenerateCommitMessageErrorEnum.emptyMessage);
+
+      return combinedCommitMessage;
     }
 
     const messages = await generateCommitMessageChatCompletionPrompt(diff, issueID);

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,6 +1,6 @@
 {
   "localLanguage": "english",
   "commitFix": "fix: AB-1234: change port variable case from lowercase port to uppercase PORT to improve semantics",
-  "commitFeat": "feat: AB-1234: add support for process.env.PORT environment variable to be able to run app on a configurable port",
+  "commitFeat": "feat: AB-1234: add support for process.env.PORT environment variable to be able to run app on a configurable port and change port variable name to uppercase PORT",
   "commitDescription": "The port variable is now named PORT, which improves consistency with the naming conventions as PORT is a constant. Support for an environment variable allows the application to be more flexible as it can now run on any available port specified via the process.env.PORT environment variable."
 }

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -73,8 +73,7 @@ const INIT_CONSISTENCY_PROMPT = (
   translation: ConsistencyPrompt
 ): ChatCompletionRequestMessage => ({
   role: ChatCompletionRequestMessageRoleEnum.Assistant,
-  content: `${config?.OCO_EMOJI ? '🐛 ' : ''}${translation.commitFix}
-${config?.OCO_EMOJI ? '✨ ' : ''}${translation.commitFeat}
+  content: `${config?.OCO_EMOJI ? '🐛 ' : ''}${translation.commitFeat}
 ${config?.OCO_DESCRIPTION ? translation.commitDescription : ''}`
 });
 

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -20,7 +20,9 @@ export const IDENTITY =
 
 const INIT_MAIN_PROMPT = (language: string, issueID: string): ChatCompletionRequestMessage => ({
   role: ChatCompletionRequestMessageRoleEnum.System,
-  content: `${IDENTITY} Your mission is to create clean and comprehensive commit messages as per the conventional commit convention and explain WHAT were the changes and mainly WHY the changes were done. I'll send you an output of 'git diff --staged' command, and you are to convert it into a commit message.
+  content: `${IDENTITY} Your mission is to create a clean and comprehensive commit message as per the conventional commit convention and explain WHAT were the changes and mainly WHY the changes were done. 
+  I'll send you an output of 'git diff --staged' command, and you are to convert it into a commit message. 
+  Only produce a single commit message for all files combined.
     ${
       config?.OCO_EMOJI
         ? 'Use GitMoji convention to preface the commit.'
@@ -28,15 +30,15 @@ const INIT_MAIN_PROMPT = (language: string, issueID: string): ChatCompletionRequ
     }
     ${
       config?.OCO_DESCRIPTION
-        ? 'Add a short description of WHY the changes are done after the commit message. Don\'t start it with "This commit", just describe the changes.'
-        : "Don't add any descriptions to the commit, only commit message."
+        ? 'Add a short description of WHY the changes are done after the single commit message title. Don\'t start it with "This commit", just describe the changes.'
+        : "Your response should just be one line with a commit message title and no description."
     }
     ${
       config?.OCO_ISSUE_ENABLED
         ? `You must also include the Issue ID: ${issueID} in the commit message title.`
         : 'Don\'t include an Issue ID in the commit message title.'
     }
-    Use the present tense. Lines must not be longer than 74 characters. Use ${language} for the commit message.`
+    Use the present tense. Lines must not be longer than 72 characters. Use ${language} for the commit message.`
 });
 
 export const INIT_DIFF_PROMPT: ChatCompletionRequestMessage = {


### PR DESCRIPTION
- Added new function to summarise commit messages when the git diff gets split into multiple calls
- Changed main prompt to only output single commit messages
- Updated English example - only commitFeat is now used by the code